### PR TITLE
Keepcolumns

### DIFF
--- a/src/main/scala/application/Config.scala
+++ b/src/main/scala/application/Config.scala
@@ -9,6 +9,7 @@ case class Config(in: File = new File(""), out: File = new File(""),
                   namecolumn: String="", numcore: Int=1,
                   rules: File = new File(""),
                   csv: Boolean = false, tab: Boolean = false,
+                  keep: Seq[String] = Seq(),
                   mode: String="")
 {
 

--- a/src/main/scala/nlp/preprocess/filters/TwitterFilter.scala
+++ b/src/main/scala/nlp/preprocess/filters/TwitterFilter.scala
@@ -27,7 +27,12 @@ trait TwitterFilter extends Filter {
       if (row.get(struct.target.get).nonEmpty) {
         val tweet = row(struct.target.get).replaceAll(TwitterRegex.searchPattern.toString(), "")
         if (tweet.trim.nonEmpty && tweet.split(" ").length >= 2) {
-          result += Seq(struct.getIdValue(row).getOrElse(row("file_name")), tweet)
+          val keep = struct.getKeepColumnsValue(row)
+          val seqnormal = Seq(struct.getIdValue(row).getOrElse(row("file_name")), tweet)
+          if(keep.isEmpty)
+            result += seqnormal
+          else
+            result += seqnormal ++ keep.get
         }
       }
     }

--- a/src/main/scala/nlp/preprocess/filters/TwitterMispellingFilter.scala
+++ b/src/main/scala/nlp/preprocess/filters/TwitterMispellingFilter.scala
@@ -37,7 +37,12 @@ trait TwitterMispellingFilter extends Filter {
            if (replaceWord.nonEmpty) counts += 1
            replaceWord.getOrElse(word)
          }.mkString(" ")
-        result += Seq(struct.getIdValue(row).getOrElse("id"), sen) ++ struct.getKeepColumnsValue(row).get
+        val keep = struct.getKeepColumnsValue(row)
+        val seqnormal = Seq(struct.getIdValue(row).getOrElse("id"), sen)
+        if(keep.isEmpty)
+          result += seqnormal
+        else
+          result += seqnormal ++ keep.get
       }
     }
 

--- a/src/main/scala/nlp/preprocess/filters/TwitterNewFilter.scala
+++ b/src/main/scala/nlp/preprocess/filters/TwitterNewFilter.scala
@@ -7,9 +7,9 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * These are pre-processing filters
  *
- * TwitterFilter is taken from CMU Ark
+ * TwitterNewFilter is taken from CMU Ark
  * library, it's used to take out URL
- * and emoticons
+ * ,emoticons and twitter mentions
  *
  * usage guide: .replaceAll(searchPattern.toString(), "")
  */
@@ -26,7 +26,12 @@ trait TwitterNewFilter extends Filter {
       if (row.get(struct.target.get).nonEmpty) {
         val tweet = row(struct.target.get).replaceAll(TwitterRegex.searchPattern.toString(), "")
         if (tweet.trim.nonEmpty && tweet.split(" ").length >= 2) {
-          result += Seq(struct.getIdValue(row).getOrElse(row("file_name")), tweet)
+          val keep = struct.getKeepColumnsValue(row)
+          val seqnormal = Seq(struct.getIdValue(row).getOrElse(row("file_name")), tweet)
+          if(keep.isEmpty)
+            result += seqnormal
+          else
+            result += seqnormal ++ keep.get
         }
       }
     }


### PR DESCRIPTION
`clean` command could now perform a "keepColumn" integration with all available preprocessing Filters (for tweets). Added a new command-line option.
